### PR TITLE
encodeURI the href to prevent XSS attacks via ending the quote and adding arbitrary scripts in onmouseover/onclick

### DIFF
--- a/ba-linkify.js
+++ b/ba-linkify.js
@@ -98,7 +98,7 @@ window.linkify = (function(){
     
     default_options = {
       callback: function( text, href ) {
-        return href ? '<a href="' + href + '" title="' + href + '">' + text + '</a>' : text;
+        return href ? '<a href="' + encodeURI(href) + '" title="' + encodeURI(href) + '">' + text + '</a>' : text;
       },
       punct_regexp: /(?:[!?.,:;'"]|(?:&|&amp;)(?:lt|gt|quot|apos|raquo|laquo|rsaquo|lsaquo);)$/
     };


### PR DESCRIPTION
Without this fix, a link such as:

http://xss.com/"onmouseover=alert('XSS');//

is a vulnerability.

I don't know how to minify the code so it would need a regen of the minified code, but this addresses the issue AFAIK.
